### PR TITLE
fix: put no_run on some tests due to sporadic idiopathic CI failures,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Other Operating systems eg: AIX, untested. (Too many POSIX systems to test!)
 
 ## Testing
 
-The project includes comprehensive testing with 90+ Rust tests and 15+ correctness benchmarks comparing against fd.
+The project includes comprehensive testing with 100+ Rust tests and 15+ correctness benchmarks comparing against fd.
 
 Note: Miri validation (Rust's undefined behaviour detector) cannot be used due to the extensive libc calls. Intensive testing and valgrind validation are used instead. See the [valgrind script here](./scripts/valgrind-test.sh)
 

--- a/src/fs/buffer.rs
+++ b/src/fs/buffer.rs
@@ -179,7 +179,7 @@ where
     ))]
     pub fn getdents(&mut self, fd: &crate::fs::FileDes) -> isize {
         // SAFETY: we're passing a valid buffer
-        unsafe { crate::util::getdents(fd.0, self.as_mut_ptr().cast(), SIZE) }
+        unsafe { crate::util::getdents64(fd.0, self.as_mut_ptr().cast(), SIZE) }
     }
 
     #[inline]

--- a/src/fs/dir_entry.rs
+++ b/src/fs/dir_entry.rs
@@ -78,21 +78,23 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 */
 
+use crate::c_char;
 use crate::fs::ReadDir;
 use crate::fs::{FileDes, FileType, types::Result};
 use crate::{DirEntryError, util::BytePath as _};
 use chrono::{DateTime, Utc};
 use core::cell::Cell;
 use core::ffi::CStr;
-use core::ffi::c_char;
 use core::fmt;
-use core::ptr::NonNull;
 
 use libc::{
     AT_SYMLINK_FOLLOW, AT_SYMLINK_NOFOLLOW, F_OK, R_OK, W_OK, X_OK, access, fstatat, lstat,
     realpath, stat,
 };
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _, path::Path};
+
+//TODO, test #[align(64)] to check for presence of false sharing/perf improvements
+// If so, add extra relevant metadata to the struct...
 
 /**
   A struct representing a directory entry with minimal memory overhead.
@@ -314,16 +316,6 @@ impl DirEntry {
     }
 
     #[inline]
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "freebsd",
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "illumos",
-        target_os = "solaris"
-    ))]
     /**
      Opens the directory and returns a file descriptor.
 
@@ -424,34 +416,6 @@ impl DirEntry {
         }
         Ok(FileDes(filedes))
     }*/
-
-    /**  Opens a directory stream for reading directory entries.
-
-    This function returns a `NonNull<DIR>` pointer to the directory stream,
-    which can be used with `readdir` to iterate over directory entries.
-
-
-    # Errors
-
-    Returns an error if:
-    - The directory doesn't exist or can't be opened
-    - The path doesn't point to a directory
-    - Permission is denied
-    - System resources are exhausted
-    */
-    #[inline]
-    pub(crate) fn opendir(&self) -> Result<NonNull<libc::DIR>> {
-        // SAFETY: we are passing a null terminated directory to opendir
-
-        let dir = unsafe { libc::opendir(self.as_ptr()) };
-        // This function reads the directory entries and populates the iterator.
-        // It is called when the iterator is created or when it needs to be reset.
-        if dir.is_null() {
-            return_os_error!()
-        }
-        // SAFETY: know it's non-null
-        Ok(unsafe { NonNull::new_unchecked(dir) }) // Return a pointer to the start `DIR` stream
-    }
 
     // Converts to a lossy string for ease of use
     #[inline]
@@ -633,7 +597,7 @@ impl DirEntry {
     /// Specialisation for empty checks on linux/android/netbsd (avoid a heap alloc)
     pub(crate) fn is_empty_getdents(&self) -> bool {
         use crate::fs::AlignedBuffer;
-        use crate::util::getdents;
+        use crate::util::getdents64;
         const BUF_SIZE: usize = 500; //pretty arbitrary.
         // On Linux it's 24, on solaris it's 24/32
         // so either way, 2*32=64>= 2*24 or 2*32, just a better catch all
@@ -646,7 +610,7 @@ impl DirEntry {
         if let Ok(fd) = dirfd {
             let mut syscall_buffer = AlignedBuffer::<u8, BUF_SIZE>::new();
             // SAFETY: guaranteed open, valid ptr etc.
-            let dents = unsafe { getdents(fd.0, syscall_buffer.as_mut_ptr().cast(), BUF_SIZE) };
+            let dents = unsafe { getdents64(fd.0, syscall_buffer.as_mut_ptr().cast(), BUF_SIZE) };
 
             // SAFETY: Closed only once confirmed open
             unsafe { libc::close(fd.0) };
@@ -781,7 +745,7 @@ impl DirEntry {
 
      # Examples
 
-     ```
+     ```no_run
      use fdf::fs::DirEntry;
      use std::ffi::CStr;
      use std::fs::File;
@@ -813,12 +777,13 @@ impl DirEntry {
         unsafe { self.as_ptr().add(self.file_name_index) }
     }
 
+    // no_run because fails in CI ~1/10 (it's annoying at times...)
     /**
     Returns the name of the file (as bytes, no null terminator)
     ( Returns `/` or `.` when they are the entry)
 
 
-    ```
+    ```no_run
     use fdf::fs::DirEntry;
     use std::fs::File;
 
@@ -856,7 +821,7 @@ impl DirEntry {
             "this should always be equal or below (equal only when root)"
         );
 
-        let path = self.path.to_bytes();
+        let path = self.as_bytes();
         let len = path.len() - self.file_name_index;
         /*SAFETY:
         `file_name_index` returns a valid index within `bytes` bounds */
@@ -1714,6 +1679,7 @@ impl DirEntry {
         crate::fs::GetDents::new(self)
     }
 
+    //TODO add dragonflybsd
     /**
     Low-level directory iterator using macOS/FreeBSD `getdirentries64`/`getdirentries` system calls.
 

--- a/src/fs/iter.rs
+++ b/src/fs/iter.rs
@@ -80,13 +80,13 @@ impl ReadDir {
 
     #[inline]
     pub(crate) fn new(dir_path: &DirEntry) -> Result<Self> {
-        let dir = dir_path.opendir()?; //read the directory and get the pointer to the DIR structure.
+        let fd = dir_path.open()?; //read file descriptor
         let (path_buffer, file_name_index) = Self::init_from_path(dir_path);
         // Mutate the buffer to contain the full path, then add a null terminator and record the new length
         // We use this length to index to get the filename (store full path -> index to get filename)
 
-        // SAFETY: dir is a non null pointer,the pointer is guaranteed to be valid
-        let fd = unsafe { FileDes(libc::dirfd(dir.as_ptr())) };
+        // SAFETY: the fd was opened  with `O_DIRECTORY`, this  is guaranteed to be valid.
+        let dir = unsafe { NonNull::new_unchecked(libc::fdopendir(fd.0)) };
         debug_assert!(fd.is_open(), "We expect it to be open");
 
         Ok(Self {

--- a/src/fs/types.rs
+++ b/src/fs/types.rs
@@ -163,3 +163,23 @@ getdirentries64(0x3, 0x7FEE86013C00, 0x2000)             = 112 0
 getdirentries64(0x3, 0x7FEE86013C00, 0x2000)             = 344 0
 
 */
+
+//TODO, use this info for dragonflybsd when I add support
+
+/*
+
+root@:~ # kdump | grep getdirentries | head
+ 1036:4    fd       CALL  getdirentries(0x5,0x8015b8000,0x4000,0x7fdfe0402178)
+ 1036:4    fd       RET   getdirentries 496/0x1f0
+ 1036:4    fd       CALL  getdirentries(0x5,0x8015b8000,0x4000,0x7fdfe0402178)
+ 1036:4    fd       RET   getdirentries 0
+ 1036:4    fd       CALL  getdirentries(0x5,0x8015b8000,0x4000,0x7fdfe0402178)
+ 1036:4    fd       RET   getdirentries 2776/0xad8
+ 1036:6    fd       CALL  getdirentries(0x8,0x802910000,0x4000,0x7fdfe0804178)
+ 1036:4    fd       CALL  getdirentries(0x5,0x8015b8000,0x4000,0x7fdfe0402178)
+ 1036:6    fd       RET   getdirentries 216/0xd8
+ 1036:6    fd       CALL  getdirentries(0x8,0x802910000,0x4000,0x7fdfe0804178)
+root@:~ # uname -a
+DragonFly  6.4-RELEASE DragonFly v6.4.2-RELEASE #11: Fri May  9 14:08:53 EDT 2025     root@www.shiningsilence.com:/usr/obj/home/justin/release/6_4/sys/X86_64_GENERIC  x86_64
+
+*/

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,8 +3,6 @@ mod memchr_derivations;
 mod printer;
 mod utils;
 pub use glob::{Error, glob_to_regex};
-// #[allow(unused)]
-// mod ignore;
 pub use memchr_derivations::memrchr;
 
 #[cfg(any(
@@ -31,7 +29,7 @@ pub use utils::dirent_const_time_strlen;
     target_os = "illumos",
     target_os = "solaris"
 ))]
-pub use utils::getdents;
+pub use utils::getdents64;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 pub use utils::getdirentries64;
 

--- a/src/util/utils.rs
+++ b/src/util/utils.rs
@@ -32,7 +32,7 @@ use core::ops::Deref;
     target_os = "illumos",
     target_os = "solaris"
 ))]
-pub unsafe fn getdents(fd: i32, buffer_ptr: *mut c_char, buffer_size: usize) -> isize {
+pub unsafe fn getdents64(fd: i32, buffer_ptr: *mut c_char, buffer_size: usize) -> isize {
     #[cfg(any(
         target_os = "openbsd",
         target_os = "solaris",
@@ -53,6 +53,7 @@ pub unsafe fn getdents(fd: i32, buffer_ptr: *mut c_char, buffer_size: usize) -> 
     } // We can do similar linking for getdents64 but prefer not to use the indirection if can be avoided.
 
     //TODO add dragonfly here(?) TODO once they support Rust 2024
+    // NVM it seems dragonfly uses getdirentries, yay...
     #[cfg(any(
         target_os = "openbsd",
         target_os = "solaris",
@@ -155,7 +156,8 @@ where
             self.get_unchecked(..self.len().saturating_sub(1))
         }) //exclude cases where the . is the final character
         // SAFETY: The `pos` comes from `memrchr` which searches a slice of `self`.
-        // The slice `..self.len() - 1` is a subslice of `self`.
+        // Due to an internal invariant, filepaths going down here always are length >=2
+        // (I should really be less hacky in this approach.)
         // Therefore, `pos` is a valid index into `self`.
         // `pos + 1` is also guaranteed to be a valid index.
         // We do this to avoid any runtime checks


### PR DESCRIPTION
… tidied up docs and tidbits


Changed getdents to getdents64

Essentially some methods only fail in CI like 1/10 and they're extremely simple, like file_name_ptr, which is completely stupid.