### PR TITLE
fix: provide increased safety  for all macos targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ fdf is a high-performance POSIX file finder written in Rust with extensive C FFI
 
 It serves as a lightweight alternative to tools such as fd and find, with a focus on speed, efficiency, and cross-platform compatibility. Benchmarks demonstrate fdf running up to 2x faster than comparable tools, achieved through low-level optimisation, SIMD techniques, and  direct syscalls(where possible).
 
+Note, my philosophy is to keep this non-publicised at at all until a 1.0.
+
 PLEASE NOTE: This is due to undergo a rename before a 1.0, I am tending towards `frep` as a name
 
 **Quick Installation:**

--- a/src/fs/iter.rs
+++ b/src/fs/iter.rs
@@ -575,14 +575,32 @@ impl GetDirEntries {
         unsafe { self.syscall_buffer.as_ptr().byte_add(amt) }
     }
 
+    pub const BUFFER_SIZE: usize = SyscallBuffer::BUFFER_SIZE;
+
     #[inline]
     #[allow(clippy::cast_sign_loss)]
     #[allow(clippy::cast_ptr_alignment)]
     #[allow(unfulfilled_lint_expectations)] //For platform variants with EOF trick.
     pub(crate) fn are_more_entries_remaining(&mut self) -> bool {
         // Early return if we've already reached end of stream
+
         if self.end_of_stream {
             return false;
+        }
+
+        #[cfg(has_eof_trick)]
+        {
+            // If using the EOF trick, initialise the last 4 bytes of the buffer with 0,
+            // this means that we detect when the kernel writes it's EOF flags
+            // SAFETY: Buffer is aligned to 8 bytes->aligned to 4, the write is in bounds by construction
+            // so alignment met+accessing valid(but uinitialised) memory.
+            unsafe {
+                self.syscall_buffer
+                    .as_mut_ptr()
+                    .byte_add(Self::BUFFER_SIZE - 4)
+                    .cast::<u32>()
+                    .write(0)
+            }
         }
 
         //SAFETY: passing a valid buffer to an open file descriptor.
@@ -590,6 +608,7 @@ impl GetDirEntries {
             self.syscall_buffer
                 .getdirentries64(&self.fd, &mut self.base_pointer)
         };
+
         let is_more_remaining = remaining_bytes.is_positive();
         // Only macOS has this optimisation, the other BSD's do not
         #[cfg(has_eof_trick)] // Check at build time for the optimisation
@@ -607,7 +626,7 @@ impl GetDirEntries {
             debug_assert!(
                 // SAFETY: as comments suggest.
                 unsafe {
-                    self.buffer_add(SyscallBuffer::BUFFER_SIZE - 4)
+                    self.buffer_add(Self::BUFFER_SIZE - 4)
                         .cast::<u32>()
                         .is_aligned()
                 },
@@ -618,7 +637,7 @@ impl GetDirEntries {
             // SAFETY: the fundamentally buffer is always aligned to a multiple of 8, which means it's always aligned for 4 byte->u32 access
             // as debug assert above shows
             unsafe {
-                self.buffer_add(SyscallBuffer::BUFFER_SIZE - 4)
+                self.buffer_add(Self::BUFFER_SIZE - 4)
                     .cast::<u32>()
                     .read()
                     == 1


### PR DESCRIPTION
Just add quick EOF field write, so that the system will never read unitialised memory (incase older mac versions don't), this is largely just a mildly safety change with realistically negligible impact on performance.